### PR TITLE
removed formatting of output to enable object property navigation

### DIFF
--- a/Get-MELCloudContextKey.psm1
+++ b/Get-MELCloudContextKey.psm1
@@ -108,7 +108,7 @@ PROCESS {
 
             $obj = New-Object -TypeName PSObject -Property $Properties
 
-            Write-Output $obj | Format-Table ContextKey, RegistredOwner, CountryName, LanguageCode
+            Write-Output $obj
 
             
             

--- a/Get-MELCloudDevice.psm1
+++ b/Get-MELCloudDevice.psm1
@@ -68,7 +68,7 @@ PROCESS {
         
        foreach ($Devices in $Devices.Content) { 
 
-       $Info.value.Structure.Devices | select DeviceID,BuildingID, DeviceName, MacAddress, SerialNumber | Format-Table
+       $Info.value.Structure.Devices | select DeviceID,BuildingID, DeviceName, MacAddress, SerialNumber
 
 
        }

--- a/Get-MELCloudDeviceInfo.psm1
+++ b/Get-MELCloudDeviceInfo.psm1
@@ -101,7 +101,7 @@ PROCESS {
 END {
 
     
-    $DevInfo.value.Structure.Devices.Device | Select-Object * -ExcludeProperty ListHistory24Formatters | Format-List
+    $DevInfo.value.Structure.Devices.Device | Select-Object * -ExcludeProperty ListHistory24Formatters
     
 
 }


### PR DESCRIPTION
Thanks for this project!
If you remove formatting of the outputs it's a lot easier to work with the API.
Then you'll be able to use it like this:

```
Import-Module .\Control-MELCloudDevice.psd1
$context = Get-MELCloudContextKey <myuser>
$device = Get-MELCloudDevice -ContextKey $context.ContextKey
$deviceInfo = Get-MELCloudDeviceInfo -ContextKey $context.ContextKey  
```